### PR TITLE
fix: solve some unrealistic company prices

### DIFF
--- a/src/companies/datasources/yahoo-financial-data.client.ts
+++ b/src/companies/datasources/yahoo-financial-data.client.ts
@@ -93,10 +93,10 @@ export class YahooFinancialDataClient implements IFinancialDataClient {
       uuid: uuidv4(),
       timestamp: Date.now(),
       price: Number(
-        summaryDetail?.ask?.raw ||
-          summaryDetail?.bid?.raw ||
-          summaryDetail?.open?.raw ||
-          summaryDetail?.previousClose?.raw,
+        summaryDetail?.bid?.raw ??
+          summaryDetail?.previousClose?.raw ??
+          summaryDetail?.open?.raw ??
+          summaryDetail?.ask?.raw,
       ),
       currency: summaryDetail?.currency,
       peg: peg < 500 ? peg : 0,


### PR DESCRIPTION
This pull request makes a minor adjustment to the logic for selecting the price value in the `YahooFinancialDataClient`. The order of precedence for price sources has been changed to prioritize `bid` and `previousClose` over `open` and `ask`. This should improve the accuracy of the price data returned.

* Changed the order of fallback values for the `price` field in `YahooFinancialDataClient`, now preferring `bid` and `previousClose` before `open` and `ask`.